### PR TITLE
sim/common/sim-events.c: Fix the wrong spelling.

### DIFF
--- a/sim/common/sim-events.c
+++ b/sim/common/sim-events.c
@@ -561,7 +561,7 @@ sim_events_schedule_after_signal (SIM_DESC sd,
   if (events->nr_held > MAX_NR_SIGNAL_SIM_EVENTS)
     {
       sim_engine_abort (NULL, NULL, NULL_CIA,
-			"sim_events_schedule_after_signal - buffer oveflow");
+			"sim_events_schedule_after_signal - buffer overflow");
     }
 
   new_event->data = data;


### PR DESCRIPTION
I found out a spelling mistake in the sim-event.c.
